### PR TITLE
[codex] SDK 기반 텔레그램 UX 정리

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,152 @@
+{
+  "name": "codex-telegram-bot",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "codex-telegram-bot",
+      "version": "0.1.0",
+      "dependencies": {
+        "@openai/codex-sdk": "^0.117.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.117.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.117.0.tgz",
+      "integrity": "sha512-UmWo39UCGqFB2ImWwtI/TOnVQ1M2JIbCeDVBzOtG57WuTIPBNvDyluPNrzNv6eAcTYpyDLC5+nT5k49LrzEwow==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.117.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.117.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.117.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.117.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.117.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.117.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.117.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-darwin-arm64.tgz",
+      "integrity": "sha512-atIlp7v15chsfMpypW8/4PBp6kOca8wBZoC0hdAWGl/PKZ76/cTC+LKi2XhRfMqKY25nUxnXnm1DnLHqWGKRXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.117.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-darwin-x64.tgz",
+      "integrity": "sha512-/TWwOtzo44flOQptQTyu+zozESNpsm/jLlK+6vEjOVikXF+kxeA7sgJHRQQ78dFvnHTW+EpkUYew5qNawREtgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.117.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-linux-arm64.tgz",
+      "integrity": "sha512-rgQIYipgkMRGvDlK3qbI9v/3NxB1tO3OoNYkWW9onOcev8Jno+hZC0ZEcVamxC5XGspVuPv2Wg+e9hw6jA65FA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.117.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-linux-x64.tgz",
+      "integrity": "sha512-kvOZtyLAgFEFSFRJXVzTnFYoZgZya9ttpxDYHR+diBgDBlcBp1B6pRiIGUmCOauxpHtTFUEyisvhKQquZbAtfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-sdk": {
+      "version": "0.117.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex-sdk/-/codex-sdk-0.117.0.tgz",
+      "integrity": "sha512-qJxkBEf3ninCC18g3YypNJ149byASwTdC9eyE060CsSBMCGZN5RNeQhYJxGjGcVFKaysWCXZ16SMzmYlcLAKVw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@openai/codex": "0.117.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.117.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-win32-arm64.tgz",
+      "integrity": "sha512-oglr9IEh0P3cXF1LyGE4ROR6OFOJ7zmOZppoS+FJR6ovaPb08RhfXCDq/1yyzZhCYIaL6GHIdJ56ZEfpM4FuCQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.117.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.117.0-win32-x64.tgz",
+      "integrity": "sha512-ByedNwSlHJ4aE2++fBaUcaqbQsmx2dZS6mhrnv2SqbTY0saRFE2BT1R64fClt8TwXwMsQQn1uvkxjzU4aEhRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "@openai/codex-sdk": "^0.117.0"
   }
 }

--- a/src/codex-sdk.js
+++ b/src/codex-sdk.js
@@ -1,0 +1,82 @@
+import { Codex } from "@openai/codex-sdk";
+
+import { buildCodexChildEnv } from "./child-env.js";
+
+let codexClient = null;
+
+function getCodexClient() {
+  if (!codexClient) {
+    codexClient = new Codex({
+      env: buildCodexChildEnv(),
+    });
+  }
+
+  return codexClient;
+}
+
+function buildThreadOptions(session, { model = "", fullAuto = false, skipGitRepoCheck = false } = {}) {
+  const options = {
+    workingDirectory: session.cwd,
+    skipGitRepoCheck,
+  };
+
+  if (model) {
+    options.model = model;
+  }
+
+  if (fullAuto) {
+    options.approvalPolicy = "on-request";
+    options.sandboxMode = "workspace-write";
+  }
+
+  return options;
+}
+
+function getThread(session, options) {
+  const client = getCodexClient();
+  const threadOptions = buildThreadOptions(session, options);
+
+  if (session.threadId) {
+    return client.resumeThread(session.threadId, threadOptions);
+  }
+
+  return client.startThread(threadOptions);
+}
+
+export async function runCodexSdkTurn(
+  session,
+  prompt,
+  { onEvent = () => {}, signal, model = "", fullAuto = false, skipGitRepoCheck = false } = {},
+) {
+  const thread = getThread(session, {
+    model,
+    fullAuto,
+    skipGitRepoCheck,
+  });
+  const { events } = await thread.runStreamed(prompt, { signal });
+
+  let lastAgentMessage = "";
+  let usage = null;
+
+  for await (const event of events) {
+    onEvent(event, thread);
+
+    if (
+      event.type === "item.completed" &&
+      event.item?.type === "agent_message" &&
+      typeof event.item.text === "string"
+    ) {
+      lastAgentMessage = event.item.text;
+    }
+
+    if (event.type === "turn.completed") {
+      usage = event.usage;
+    }
+  }
+
+  return {
+    threadId: thread.id,
+    text: lastAgentMessage.trim(),
+    usage,
+  };
+}

--- a/src/codex-sdk.js
+++ b/src/codex-sdk.js
@@ -3,12 +3,17 @@ import { Codex } from "@openai/codex-sdk";
 import { buildCodexChildEnv } from "./child-env.js";
 
 let codexClient = null;
+let codexClientEnvKey = "";
 
 function getCodexClient() {
-  if (!codexClient) {
+  const env = buildCodexChildEnv();
+  const envKey = JSON.stringify(env);
+
+  if (!codexClient || codexClientEnvKey !== envKey) {
     codexClient = new Codex({
-      env: buildCodexChildEnv(),
+      env,
     });
+    codexClientEnvKey = envKey;
   }
 
   return codexClient;

--- a/src/index.js
+++ b/src/index.js
@@ -756,6 +756,7 @@ async function processSessionPrompt(chatId, label, prompt, progressMessageId = n
   };
   let lastProgressText = "";
   let progressChain = Promise.resolve();
+  const maxProgressSteps = 10;
 
   function queueProgress(step, overrides = {}) {
     if (overrides.threadId) {
@@ -766,6 +767,9 @@ async function processSessionPrompt(chatId, label, prompt, progressMessageId = n
     }
     if (step && progressState.steps.at(-1) !== step) {
       progressState.steps.push(step);
+      if (progressState.steps.length > maxProgressSteps) {
+        progressState.steps = progressState.steps.slice(-maxProgressSteps);
+      }
     }
     if (!progressMessageId) {
       return;
@@ -777,7 +781,9 @@ async function processSessionPrompt(chatId, label, prompt, progressMessageId = n
     lastProgressText = nextText;
     progressChain = progressChain
       .then(() => editText(chatId, progressMessageId, nextText, { parse_mode: "MarkdownV2" }))
-      .catch(() => {});
+      .catch((error) => {
+        console.warn(`[progress] ${error?.message || error}`);
+      });
   }
 
   try {
@@ -1008,7 +1014,8 @@ function summarizeCommandForProgress(command) {
     return "명령";
   }
 
-  let summary = String(command).replace(/\s+/g, " ").trim();
+  const rawCommand = Array.isArray(command) ? command.join(" ") : String(command);
+  let summary = rawCommand.replace(/\s+/g, " ").trim();
   if (summary.startsWith("/bin/bash -lc ")) {
     summary = summary.slice("/bin/bash -lc ".length);
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,6 @@
-import fs from "node:fs/promises";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import os from "node:os";
-import { spawn } from "node:child_process";
-import readline from "node:readline";
 import { setTimeout as delay } from "node:timers/promises";
 import {
   sanitizeSegment,
@@ -11,7 +8,6 @@ import {
   splitLabel,
 } from "./lib/utils.js";
 import { loadStateFile, writeJsonAtomic } from "./lib/state.js";
-import { buildCodexChildEnv } from "./child-env.js";
 import { UserVisibleError, logError, toUserMessage } from "./errors.js";
 import {
   buildBackToMenuKeyboard,
@@ -37,6 +33,8 @@ import {
   formatWhoAmI,
   helpText,
   menuHomeText,
+  renderError,
+  renderProgress,
   renderReply,
 } from "./menu.js";
 import { createTelegramClient } from "./telegram.js";
@@ -47,6 +45,7 @@ import {
   removeManagedWorktree,
   resolveRepoRoot,
 } from "./git.js";
+import { runCodexSdkTurn } from "./codex-sdk.js";
 
 loadDotEnv(path.resolve(process.cwd(), ".env"));
 
@@ -79,6 +78,13 @@ const recentSessionStore = createRecentSessionStore(CODEX_SESSIONS_ROOT, RECENT_
 
 const state = await loadStateFile(STATE_PATH, DEFAULT_CWD);
 const backgroundJobs = new Set();
+
+class SessionCanceledError extends Error {
+  constructor() {
+    super("session canceled");
+    this.name = "SessionCanceledError";
+  }
+}
 
 console.log(`[boot] state=${STATE_PATH}`);
 console.log(`[boot] default cwd=${DEFAULT_CWD}`);
@@ -181,9 +187,16 @@ async function handleUpdate(update) {
     latestSession.updatedAt = now();
     latestSession.lastUserMessage = text;
   });
-  await sendText(chatId, `세션 \`${activeLabel}\` 작업을 시작합니다.`);
+  const progressMessage = await sendText(
+    chatId,
+    renderProgress(activeLabel, {
+      threadId: session.threadId,
+      statusText: "시작됨",
+      steps: ["요청 전달 완료", "Codex 준비 중"],
+    }),
+  );
 
-  const job = processSessionPrompt(chatId, activeLabel, text).finally(
+  const job = processSessionPrompt(chatId, activeLabel, text, progressMessage?.message_id ?? null).finally(
     () => backgroundJobs.delete(job),
   );
   backgroundJobs.add(job);
@@ -202,6 +215,7 @@ async function handleCommand(chatId, chat, message, text) {
     case "/help":
       await sendText(chatId, helpText());
       return;
+    case "/threads":
     case "/sessions":
       await sendText(chatId, formatSessions(chat));
       return;
@@ -220,6 +234,7 @@ async function handleCommand(chatId, chat, message, text) {
       await sendText(chatId, formatRecentSessions(recentSessions, limit, CODEX_SESSIONS_ROOT));
       return;
     }
+    case "/thread":
     case "/status":
       await sendText(chatId, formatStatus(chat, chat.activeSessionKey));
       return;
@@ -354,10 +369,11 @@ async function handleCommand(chatId, chat, message, text) {
       await sendText(chatId, message);
       return;
     }
+    case "/resume":
     case "/reopen": {
       const label = parts[0];
       if (!label || !chat.sessions[label]) {
-        await sendText(chatId, "사용법: `/reopen 세션명`");
+        await sendText(chatId, "사용법: `/resume 세션명` 또는 `/reopen 세션명`");
         return;
       }
       await mutateState(() => {
@@ -369,6 +385,7 @@ async function handleCommand(chatId, chat, message, text) {
       await sendText(chatId, `세션 \`${label}\` 을 다시 열고 활성 세션으로 지정했습니다.`);
       return;
     }
+    case "/cwd":
     case "/where": {
       const session = getActiveSession(chat);
       if (!session) {
@@ -724,15 +741,47 @@ async function handlePendingNewSessionInput(chatId, chat, text) {
   return true;
 }
 
-async function processSessionPrompt(chatId, label, prompt) {
+async function processSessionPrompt(chatId, label, prompt, progressMessageId = null) {
   const chat = ensureChat(chatId);
   const session = chat.sessions[label];
   if (!session) {
     return;
   }
 
+  const progressState = {
+    threadId: session.threadId ?? "",
+    statusText: "실행 중",
+    steps: ["Codex 응답 대기 중"],
+  };
+  let lastProgressText = "";
+  let progressChain = Promise.resolve();
+
+  function queueProgress(step, overrides = {}) {
+    if (overrides.threadId) {
+      progressState.threadId = overrides.threadId;
+    }
+    if (overrides.statusText) {
+      progressState.statusText = overrides.statusText;
+    }
+    if (step && progressState.steps.at(-1) !== step) {
+      progressState.steps.push(step);
+    }
+    if (!progressMessageId) {
+      return;
+    }
+    const nextText = renderProgress(label, progressState);
+    if (nextText === lastProgressText) {
+      return;
+    }
+    lastProgressText = nextText;
+    progressChain = progressChain
+      .then(() => editText(chatId, progressMessageId, nextText))
+      .catch(() => {});
+  }
+
   try {
-    const result = await runCodexSession(chatId, label, session, prompt);
+    queueProgress("요청 분석 중");
+    const result = await runCodexSession(chatId, label, session, prompt, queueProgress);
     const threadId = await mutateState(() => {
       const latestChat = ensureChat(chatId);
       const latestSession = latestChat.sessions[label];
@@ -745,6 +794,11 @@ async function processSessionPrompt(chatId, label, prompt) {
       latestSession.lastAssistantMessage = result.text;
       return latestSession.threadId;
     });
+    queueProgress("응답 전달 완료", {
+      threadId,
+      statusText: "완료",
+    });
+    await progressChain;
     await sendText(chatId, renderReply(label, result.text, threadId));
   } catch (error) {
     await mutateState(() => {
@@ -757,11 +811,18 @@ async function processSessionPrompt(chatId, label, prompt) {
       latestSession.updatedAt = now();
     });
     if (error instanceof SessionCanceledError) {
-      await sendText(chatId, `세션 "${label}" 실행을 취소했습니다.`);
+      queueProgress("사용자 취소 요청 반영", { statusText: "취소됨" });
+      await progressChain;
+      await sendText(chatId, renderError(label, '실행을 취소했습니다.'));
       return;
     }
+    queueProgress("실행 중 오류 발생", { statusText: "실패" });
+    await progressChain;
     logError(`session-run:${label}`, error);
-    await sendText(chatId, toUserMessage(error, `세션 \`${label}\` 실행 중 오류가 발생했습니다.`));
+    await sendText(
+      chatId,
+      renderError(label, toUserMessage(error, `세션 \`${label}\` 실행 중 오류가 발생했습니다.`)),
+    );
   }
 }
 
@@ -842,123 +903,111 @@ async function buildRecentSessionDetail(chat, sessionId) {
   ].join("\n");
 }
 
-async function runCodexSession(chatId, label, session, prompt) {
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "codex-telegram-"));
-  const outputPath = path.join(tempDir, "output.txt");
-  const args = buildCodexArgs(session, prompt, outputPath);
-  const child = spawn("codex", args, {
-    cwd: session.cwd,
-    stdio: ["ignore", "pipe", "pipe"],
-    env: buildCodexChildEnv(),
-  });
+async function runCodexSession(chatId, label, session, prompt, onProgress = () => {}) {
   const runtimeKey = sessionRuntimeKey(chatId, label);
+  const abortController = new AbortController();
   runningSessionProcesses.set(runtimeKey, {
-    child,
     cancelRequested: false,
+    abortController,
   });
 
-  let threadId = session.threadId;
-  let lastAgentMessage = "";
-  let stderr = "";
-
-  const stdoutRl = readline.createInterface({ input: child.stdout });
-  stdoutRl.on("line", (line) => {
-    try {
-      const event = JSON.parse(line);
-      if (event.type === "thread.started" && event.thread_id) {
-        threadId = event.thread_id;
-      }
-      if (
-        event.type === "item.completed" &&
-        event.item?.type === "agent_message" &&
-        typeof event.item.text === "string"
-      ) {
-        lastAgentMessage = event.item.text;
-      }
-    } catch {
-      // Ignore non-JSON lines from the CLI.
-    }
-  });
-
-  child.stderr.on("data", (chunk) => {
-    stderr += String(chunk);
-  });
-
-  const exitCode = await new Promise((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", resolve);
-  });
-  const runtime = runningSessionProcesses.get(runtimeKey);
-  runningSessionProcesses.delete(runtimeKey);
-
-  stdoutRl.close();
-
-  let finalText = "";
   try {
-    finalText = (await fs.readFile(outputPath, "utf8")).trim();
-  } catch {
-    finalText = lastAgentMessage.trim();
+    const result = await runCodexSdkTurn(session, prompt, {
+      signal: abortController.signal,
+      model: CODEX_MODEL,
+      fullAuto: CODEX_FULL_AUTO,
+      skipGitRepoCheck: CODEX_SKIP_GIT_REPO_CHECK,
+      onEvent(event) {
+        if (event.type === "thread.started" && event.thread_id) {
+          onProgress("세션 연결 완료", { threadId: event.thread_id });
+          return;
+        }
+        if (event.type === "turn.started") {
+          onProgress("요청 분석 중");
+          return;
+        }
+        if (event.type === "item.started" && event.item?.type === "command_execution") {
+          onProgress(`명령 실행 중: ${summarizeCommandForProgress(event.item.command)}`);
+          return;
+        }
+        if (event.type === "item.completed" && event.item?.type === "command_execution") {
+          const commandText = summarizeCommandForProgress(event.item.command);
+          const exitText = typeof event.item.exit_code === "number" ? ` (exit ${event.item.exit_code})` : "";
+          onProgress(`명령 완료: ${commandText}${exitText}`);
+          return;
+        }
+        if (event.type === "item.completed" && event.item?.type === "reasoning") {
+          onProgress("해결 방향 정리 중");
+          return;
+        }
+        if (
+          event.type === "item.completed" &&
+          event.item?.type === "agent_message" &&
+          typeof event.item.text === "string"
+        ) {
+          onProgress("응답 정리 중");
+          return;
+        }
+        if (event.type === "item.completed" && event.item?.type === "file_change") {
+          const changed = event.item.changes?.map((change) => change.path).filter(Boolean) ?? [];
+          const summary = changed.length > 0 ? changed.slice(0, 2).join(", ") : "파일 변경";
+          onProgress(`파일 반영: ${summary}`);
+          return;
+        }
+        if (event.type === "item.completed" && event.item?.type === "mcp_tool_call") {
+          onProgress(`도구 완료: ${event.item.server}/${event.item.tool}`);
+          return;
+        }
+        if (event.type === "item.completed" && event.item?.type === "web_search") {
+          onProgress(`검색 완료: ${event.item.query}`);
+          return;
+        }
+        if (event.type === "item.completed" && event.item?.type === "todo_list") {
+          onProgress("계획 업데이트");
+          return;
+        }
+        if (event.type === "turn.completed") {
+          onProgress("응답 마무리 중");
+        }
+      },
+    });
+
+    if (!result.threadId) {
+      throw new UserVisibleError("Codex thread_id를 추출하지 못했습니다.");
+    }
+
+    return {
+      threadId: result.threadId,
+      text: result.text || "(빈 응답)",
+    };
+  } catch (error) {
+    const runtime = runningSessionProcesses.get(runtimeKey);
+    if (runtime?.cancelRequested || error?.name === "AbortError") {
+      throw new SessionCanceledError();
+    }
+    throw error;
   } finally {
-    await fs.rm(tempDir, { recursive: true, force: true });
+    runningSessionProcesses.delete(runtimeKey);
   }
-
-  if (runtime?.cancelRequested) {
-    throw new SessionCanceledError();
-  }
-
-  if (exitCode !== 0) {
-    throw new Error((stderr || finalText || `exit code ${exitCode}`).trim());
-  }
-
-  if (!threadId) {
-    throw new UserVisibleError("Codex thread_id를 추출하지 못했습니다.");
-  }
-
-  if (!finalText) {
-    finalText = "(빈 응답)";
-  }
-
-  return {
-    threadId,
-    text: finalText,
-  };
 }
 
-function buildCodexArgs(session, prompt, outputPath) {
-  const shared = [];
-  if (CODEX_MODEL) {
-    shared.push("-m", CODEX_MODEL);
-  }
-  if (CODEX_FULL_AUTO) {
-    shared.push("--full-auto");
-  }
-  if (CODEX_SKIP_GIT_REPO_CHECK) {
-    shared.push("--skip-git-repo-check");
+function summarizeCommandForProgress(command) {
+  if (!command) {
+    return "명령";
   }
 
-  if (session.threadId) {
-    return [
-      "exec",
-      "resume",
-      "--json",
-      ...shared,
-      "-o",
-      outputPath,
-      session.threadId,
-      prompt,
-    ];
+  let summary = String(command).replace(/\s+/g, " ").trim();
+  if (summary.startsWith("/bin/bash -lc ")) {
+    summary = summary.slice("/bin/bash -lc ".length);
+  }
+  if (
+    (summary.startsWith("\"") && summary.endsWith("\"")) ||
+    (summary.startsWith("'") && summary.endsWith("'"))
+  ) {
+    summary = summary.slice(1, -1);
   }
 
-  return [
-    "exec",
-    "--json",
-    ...shared,
-    "-C",
-    session.cwd,
-    "-o",
-    outputPath,
-    prompt,
-  ];
+  return summary.length > 100 ? `${summary.slice(0, 97)}...` : summary;
 }
 
 async function sendMainMenu(chatId) {
@@ -1074,18 +1123,12 @@ async function cancelSession(chatId, chat, label) {
   }
 
   const runtime = runningSessionProcesses.get(sessionRuntimeKey(chatId, label));
-  if (!runtime?.child) {
+  if (!runtime?.abortController) {
     return `세션 "${label}" 실행 상태를 찾지 못했습니다. 잠시 후 다시 확인해주세요.`;
   }
 
   runtime.cancelRequested = true;
-  runtime.child.kill("SIGINT");
-  setTimeout(() => {
-    const latest = runningSessionProcesses.get(sessionRuntimeKey(chatId, label));
-    if (latest?.child === runtime.child) {
-      latest.child.kill("SIGTERM");
-    }
-  }, 2000).unref();
+  runtime.abortController.abort();
 
   return `세션 "${label}" 실행 취소를 요청했습니다.`;
 }
@@ -1124,13 +1167,6 @@ function collectRegisteredWorktreePaths() {
 
 function sessionRuntimeKey(chatId, label) {
   return `${chatId}::${label}`;
-}
-
-class SessionCanceledError extends Error {
-  constructor() {
-    super("session canceled");
-    this.name = "SessionCanceledError";
-  }
 }
 
 async function mutateState(mutator) {

--- a/src/index.js
+++ b/src/index.js
@@ -194,6 +194,7 @@ async function handleUpdate(update) {
       statusText: "시작됨",
       steps: ["요청 전달 완료", "Codex 준비 중"],
     }),
+    { parse_mode: "MarkdownV2" },
   );
 
   const job = processSessionPrompt(chatId, activeLabel, text, progressMessage?.message_id ?? null).finally(
@@ -775,7 +776,7 @@ async function processSessionPrompt(chatId, label, prompt, progressMessageId = n
     }
     lastProgressText = nextText;
     progressChain = progressChain
-      .then(() => editText(chatId, progressMessageId, nextText))
+      .then(() => editText(chatId, progressMessageId, nextText, { parse_mode: "MarkdownV2" }))
       .catch(() => {});
   }
 
@@ -799,7 +800,14 @@ async function processSessionPrompt(chatId, label, prompt, progressMessageId = n
       statusText: "완료",
     });
     await progressChain;
-    await sendText(chatId, renderReply(label, result.text, threadId));
+    await sendText(
+      chatId,
+      renderReply(label, result.text, threadId, {
+        branch: session.worktree?.branch ?? "",
+        usage: result.usage ?? null,
+      }),
+      { parse_mode: "MarkdownV2" },
+    );
   } catch (error) {
     await mutateState(() => {
       const latestChat = ensureChat(chatId);
@@ -813,7 +821,9 @@ async function processSessionPrompt(chatId, label, prompt, progressMessageId = n
     if (error instanceof SessionCanceledError) {
       queueProgress("사용자 취소 요청 반영", { statusText: "취소됨" });
       await progressChain;
-      await sendText(chatId, renderError(label, '실행을 취소했습니다.'));
+      await sendText(chatId, renderError(label, '실행을 취소했습니다.'), {
+        parse_mode: "MarkdownV2",
+      });
       return;
     }
     queueProgress("실행 중 오류 발생", { statusText: "실패" });
@@ -822,6 +832,7 @@ async function processSessionPrompt(chatId, label, prompt, progressMessageId = n
     await sendText(
       chatId,
       renderError(label, toUserMessage(error, `세션 \`${label}\` 실행 중 오류가 발생했습니다.`)),
+      { parse_mode: "MarkdownV2" },
     );
   }
 }
@@ -979,6 +990,7 @@ async function runCodexSession(chatId, label, session, prompt, onProgress = () =
     return {
       threadId: result.threadId,
       text: result.text || "(빈 응답)",
+      usage: result.usage ?? null,
     };
   } catch (error) {
     const runtime = runningSessionProcesses.get(runtimeKey);

--- a/src/menu.js
+++ b/src/menu.js
@@ -4,6 +4,14 @@ import {
   shortThreadId,
 } from "./lib/utils.js";
 
+function escapeTelegramMarkdown(text) {
+  return String(text).replace(/([_*\[\]()~`>#+\-=|{}.!\\])/g, "\\$1");
+}
+
+function code(value) {
+  return `\`${escapeTelegramMarkdown(value)}\``;
+}
+
 function inlineText(value) {
   if (!value) {
     return "없음";
@@ -33,24 +41,31 @@ export function helpText() {
   return [
     "Codex Telegram Bot",
     "",
-    "/menu : 버튼 메뉴 열기",
-    "/new 세션명 [cwd] : 새 세션 생성, Git repo면 전용 worktree 자동 생성",
-    "/attach 세션명 session_id|recent번호 [cwd] : 기존 Codex 세션 붙이기",
+    "Codex Core",
+    "/new 세션명 [cwd] : 새 thread 시작, Git repo면 전용 worktree 자동 생성",
+    "/thread : 현재 thread 상태 보기",
+    "/threads : 열린 세션 목록 보기",
+    "/status : 현재 활성 세션 요약 보기",
+    "/cancel [세션명] : 현재 turn 취소",
+    "/cwd : 현재 cwd, thread_id, branch 확인",
     "/use 세션명 : 활성 세션 전환",
-    "/sessions : 세션 목록 보기",
+    "/resume 세션명 : 닫힌 세션 다시 열기",
+    "",
+    "Telegram Extras",
+    "/menu : 버튼 메뉴 열기",
+    "/attach 세션명 session_id|recent번호 [cwd] : 기존 Codex 세션 붙이기",
     "/recent [개수] : 최근 Codex 세션과 cwd 보기",
-    "/status : 활성 세션 요약 보기",
-    "/cancel [세션명] : 실행 중인 작업 취소",
     "/whoami : 현재 chat_id 와 사용자 정보 보기",
     "/close [세션명] : 봇 연결 닫기",
     "/drop [세션명] : 봇 연결 삭제, 관리형 worktree도 함께 제거",
-    "/reopen 세션명 : 닫힌 세션 다시 열기",
     "/setcwd /absolute/path : 기본 cwd 저장",
-    "/where : 활성 세션의 cwd와 thread_id 확인",
+    "/where : /cwd 와 동일한 상세 정보",
+    "/sessions : /threads 와 동일한 세션 목록",
+    "/reopen 세션명 : /resume 과 동일",
     "",
-    "일반 메시지는 현재 활성 세션으로 codex exec 또는 codex exec resume 됩니다.",
+    "일반 메시지는 현재 활성 thread로 이어서 작업합니다.",
     "",
-    "참고: codex fork 는 현재 CLI에서 JSON 자동화 표면이 없어 1차 버전에서는 넣지 않았습니다.",
+    "참고: codex fork 는 현재 CLI에서 JSON 자동화 표면이 없어 아직 넣지 않았습니다.",
   ].join("\n");
 }
 
@@ -71,11 +86,11 @@ export function menuHomeText() {
 export function buildTelegramCommands() {
   return [
     { command: "menu", description: "버튼 메뉴 열기" },
+    { command: "thread", description: "현재 thread 상태 보기" },
+    { command: "threads", description: "열린 세션 목록 보기" },
+    { command: "cwd", description: "현재 cwd와 thread 확인" },
+    { command: "new", description: "새 thread 시작" },
     { command: "whoami", description: "현재 chat_id 확인" },
-    { command: "recent", description: "최근 Codex 세션 보기" },
-    { command: "sessions", description: "세션 목록 보기" },
-    { command: "status", description: "현재 세션 상태 보기" },
-    { command: "new", description: "새 세션 만들기" },
   ];
 }
 
@@ -215,7 +230,42 @@ export function formatRecentMenuText(entries, page) {
 }
 
 export function renderReply(label, text, threadId) {
-  return [`[${label}]`, "", text, "", `thread_id: ${threadId}`].join("\n");
+  const body = escapeTelegramMarkdown(text);
+  return [
+    `*\\[${escapeTelegramMarkdown(label)}\\] 결과*`,
+    "",
+    body,
+    "",
+    `*thread* ${code(threadId)}`,
+  ].join("\n");
+}
+
+export function renderProgress(label, { threadId = "", statusText = "실행 중", steps = [] } = {}) {
+  const recentSteps = steps.slice(-4);
+  const lines = [`*\\[${escapeTelegramMarkdown(label)}\\] 진행 상황*`, ""];
+
+  lines.push(`*상태* ${escapeTelegramMarkdown(statusText)}`);
+
+  if (threadId) {
+    lines.push(`*thread* ${code(threadId)}`);
+  }
+
+  if (recentSteps.length > 0) {
+    lines.push("");
+    for (const [index, step] of recentSteps.entries()) {
+      lines.push(`${index + 1}\\. ${escapeTelegramMarkdown(step)}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export function renderError(label, message) {
+  return [
+    `*\\[${escapeTelegramMarkdown(label)}\\] 오류*`,
+    "",
+    escapeTelegramMarkdown(message),
+  ].join("\n");
 }
 
 export function buildMainMenuKeyboard() {

--- a/src/menu.js
+++ b/src/menu.js
@@ -229,14 +229,47 @@ export function formatRecentMenuText(entries, page) {
   return lines.join("\n");
 }
 
-export function renderReply(label, text, threadId) {
+function formatUsage(usage) {
+  if (!usage) {
+    return null;
+  }
+
+  const formatTokenCount = (value) => {
+    if (value < 1000) {
+      return String(value);
+    }
+
+    const compact = (value / 1000).toFixed(value >= 10000 ? 0 : 1);
+    return `${compact.replace(/\.0$/, "")}k`;
+  };
+
+  const parts = [`in ${formatTokenCount(usage.input_tokens)}`];
+  if (usage.cached_input_tokens) {
+    parts.push(`cached ${formatTokenCount(usage.cached_input_tokens)}`);
+  }
+  parts.push(`out ${formatTokenCount(usage.output_tokens)}`);
+  return parts.join(" | ");
+}
+
+export function renderReply(label, text, threadId, { branch = "", usage = null } = {}) {
   const body = escapeTelegramMarkdown(text);
+  const footer = [`*thread* ${code(threadId)}`];
+
+  if (branch) {
+    footer.push(`*branch* ${code(branch)}`);
+  }
+
+  const usageText = formatUsage(usage);
+  if (usageText) {
+    footer.push(`*usage* ${escapeTelegramMarkdown(usageText)}`);
+  }
+
   return [
     `*\\[${escapeTelegramMarkdown(label)}\\] 결과*`,
     "",
     body,
     "",
-    `*thread* ${code(threadId)}`,
+    footer.join("\n"),
   ].join("\n");
 }
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -42,13 +42,6 @@ async function postJson(requestUrl, payload) {
   });
 }
 
-function withDefaultParseMode(extra = {}) {
-  return {
-    parse_mode: "MarkdownV2",
-    ...extra,
-  };
-}
-
 export function createTelegramClient(apiBaseUrl) {
   async function telegram(method, payload) {
     let lastError = null;
@@ -88,7 +81,7 @@ export function createTelegramClient(apiBaseUrl) {
         chat_id: Number(chatId),
         text: chunk,
         disable_web_page_preview: true,
-        ...(index === chunks.length - 1 ? withDefaultParseMode(extra) : withDefaultParseMode()),
+        ...(index === chunks.length - 1 ? extra : {}),
       });
     }
     return lastResult;
@@ -100,7 +93,7 @@ export function createTelegramClient(apiBaseUrl) {
       message_id: messageId,
       text,
       disable_web_page_preview: true,
-      ...withDefaultParseMode(extra),
+      ...extra,
     });
   }
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -42,6 +42,13 @@ async function postJson(requestUrl, payload) {
   });
 }
 
+function withDefaultParseMode(extra = {}) {
+  return {
+    parse_mode: "MarkdownV2",
+    ...extra,
+  };
+}
+
 export function createTelegramClient(apiBaseUrl) {
   async function telegram(method, payload) {
     let lastError = null;
@@ -75,14 +82,16 @@ export function createTelegramClient(apiBaseUrl) {
 
   async function sendText(chatId, text, extra = {}) {
     const chunks = splitTelegramText(text);
+    let lastResult = null;
     for (const [index, chunk] of chunks.entries()) {
-      await telegram("sendMessage", {
+      lastResult = await telegram("sendMessage", {
         chat_id: Number(chatId),
         text: chunk,
         disable_web_page_preview: true,
-        ...(index === chunks.length - 1 ? extra : {}),
+        ...(index === chunks.length - 1 ? withDefaultParseMode(extra) : withDefaultParseMode()),
       });
     }
+    return lastResult;
   }
 
   async function editText(chatId, messageId, text, extra = {}) {
@@ -91,7 +100,7 @@ export function createTelegramClient(apiBaseUrl) {
       message_id: messageId,
       text,
       disable_web_page_preview: true,
-      ...extra,
+      ...withDefaultParseMode(extra),
     });
   }
 

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -4,6 +4,8 @@ import { setTimeout as delay } from "node:timers/promises";
 
 import { splitTelegramText } from "./lib/utils.js";
 
+const TELEGRAM_REQUEST_TIMEOUT_MS = 30_000;
+
 async function postJson(requestUrl, payload) {
   const url = new URL(requestUrl);
   const transport = url.protocol === "https:" ? https : http;
@@ -18,7 +20,7 @@ async function postJson(requestUrl, payload) {
           "content-type": "application/json",
           "content-length": Buffer.byteLength(body),
         },
-        family: url.protocol === "https:" ? 4 : undefined,
+        family: 4,
       },
       (response) => {
         let raw = "";
@@ -36,6 +38,9 @@ async function postJson(requestUrl, payload) {
       },
     );
 
+    request.setTimeout(TELEGRAM_REQUEST_TIMEOUT_MS, () => {
+      request.destroy(new Error(`telegram request timed out after ${TELEGRAM_REQUEST_TIMEOUT_MS}ms`));
+    });
     request.on("error", reject);
     request.write(body);
     request.end();

--- a/src/telegram.js
+++ b/src/telegram.js
@@ -1,6 +1,46 @@
+import http from "node:http";
+import https from "node:https";
 import { setTimeout as delay } from "node:timers/promises";
 
 import { splitTelegramText } from "./lib/utils.js";
+
+async function postJson(requestUrl, payload) {
+  const url = new URL(requestUrl);
+  const transport = url.protocol === "https:" ? https : http;
+  const body = JSON.stringify(payload);
+
+  return new Promise((resolve, reject) => {
+    const request = transport.request(
+      url,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "content-length": Buffer.byteLength(body),
+        },
+        family: url.protocol === "https:" ? 4 : undefined,
+      },
+      (response) => {
+        let raw = "";
+        response.setEncoding("utf8");
+        response.on("data", (chunk) => {
+          raw += chunk;
+        });
+        response.on("end", () => {
+          try {
+            resolve(JSON.parse(raw));
+          } catch (error) {
+            reject(error);
+          }
+        });
+      },
+    );
+
+    request.on("error", reject);
+    request.write(body);
+    request.end();
+  });
+}
 
 export function createTelegramClient(apiBaseUrl) {
   async function telegram(method, payload) {
@@ -8,12 +48,7 @@ export function createTelegramClient(apiBaseUrl) {
 
     for (let attempt = 1; attempt <= 3; attempt += 1) {
       try {
-        const response = await fetch(`${apiBaseUrl}/${method}`, {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify(payload),
-        });
-        const body = await response.json();
+        const body = await postJson(`${apiBaseUrl}/${method}`, payload);
         if (!body.ok) {
           throw new Error(`${method} failed: ${JSON.stringify(body)}`);
         }

--- a/test/menu.test.js
+++ b/test/menu.test.js
@@ -34,11 +34,20 @@ test("helpText separates codex core and telegram extras", () => {
 });
 
 test("renderReply and renderError escape telegram markdown safely", () => {
-  const reply = renderReply("bug_fix", "path: /tmp/a-b (ok)", "thr_123");
+  const reply = renderReply("bug_fix", "path: /tmp/a-b (ok)", "thr_123", {
+    branch: "bot/50492701/511-20260329214558",
+    usage: {
+      input_tokens: 28323,
+      cached_input_tokens: 3456,
+      output_tokens: 30,
+    },
+  });
   const error = renderError("bug_fix", "failed: a_b-c");
 
   assert.match(reply, /\*\\\[bug\\_fix\\\] 결과\*/);
   assert.match(reply, /`thr\\_123`/);
+  assert.match(reply, /\*branch\* `bot\/50492701\/511\\-20260329214558`/);
+  assert.match(reply, /\*usage\* in 28\\.3k \\| cached 3\\.5k \\| out 30/);
   assert.match(reply, /path: \/tmp\/a\\-b \\\(ok\\\)/);
   assert.match(error, /\*\\\[bug\\_fix\\\] 오류\*/);
   assert.match(error, /failed: a\\_b\\-c/);

--- a/test/menu.test.js
+++ b/test/menu.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { helpText, renderError, renderProgress, renderReply } from "../src/menu.js";
+
+test("renderProgress includes status, thread id, and recent steps", () => {
+  const text = renderProgress("bugfix", {
+    threadId: "thread-123",
+    statusText: "실행 중",
+    steps: [
+      "요청 전달 완료",
+      "Codex 준비 중",
+      "요청 분석 중",
+      "명령 실행 중: pwd",
+    ],
+  });
+
+  assert.match(text, /\*\\\[bugfix\\\] 진행 상황\*/);
+  assert.match(text, /\*상태\* 실행 중/);
+  assert.match(text, /\*thread\* `thread\\-123`/);
+  assert.match(text, /1\\\. 요청 전달 완료/);
+  assert.match(text, /4\\\. 명령 실행 중: pwd/);
+});
+
+test("helpText separates codex core and telegram extras", () => {
+  const text = helpText();
+
+  assert.match(text, /Codex Core/);
+  assert.match(text, /Telegram Extras/);
+  assert.match(text, /\/thread : 현재 thread 상태 보기/);
+  assert.match(text, /\/threads : 열린 세션 목록 보기/);
+  assert.match(text, /\/cwd : 현재 cwd, thread_id, branch 확인/);
+  assert.match(text, /\/resume 세션명 : 닫힌 세션 다시 열기/);
+});
+
+test("renderReply and renderError escape telegram markdown safely", () => {
+  const reply = renderReply("bug_fix", "path: /tmp/a-b (ok)", "thr_123");
+  const error = renderError("bug_fix", "failed: a_b-c");
+
+  assert.match(reply, /\*\\\[bug\\_fix\\\] 결과\*/);
+  assert.match(reply, /`thr\\_123`/);
+  assert.match(reply, /path: \/tmp\/a\\-b \\\(ok\\\)/);
+  assert.match(error, /\*\\\[bug\\_fix\\\] 오류\*/);
+  assert.match(error, /failed: a\\_b\\-c/);
+});

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
 import http from "node:http";
 import test from "node:test";
 
@@ -59,5 +60,56 @@ test("createTelegramClient sends JSON POST requests and returns result", async (
         resolve();
       });
     });
+  }
+});
+
+test("createTelegramClient forces IPv4 and applies request timeout", async () => {
+  const originalRequest = http.request;
+  const captured = {
+    options: null,
+    timeoutMs: null,
+    body: "",
+  };
+
+  http.request = (url, options, callback) => {
+    captured.options = options;
+
+    const response = new EventEmitter();
+    response.setEncoding = () => {};
+
+    const request = new EventEmitter();
+    request.setTimeout = (timeoutMs, handler) => {
+      captured.timeoutMs = timeoutMs;
+      request.timeoutHandler = handler;
+      return request;
+    };
+    request.write = (chunk) => {
+      captured.body += chunk;
+    };
+    request.end = () => {
+      callback(response);
+      response.emit("data", JSON.stringify({ ok: true, result: { delivered: true } }));
+      response.emit("end");
+    };
+    request.destroy = () => {};
+    return request;
+  };
+
+  try {
+    const client = createTelegramClient("http://127.0.0.1:9999");
+    const result = await client.telegram("sendMessage", {
+      chat_id: 321,
+      text: "hello",
+    });
+
+    assert.deepEqual(result, { delivered: true });
+    assert.equal(captured.options.family, 4);
+    assert.equal(captured.timeoutMs, 30_000);
+    assert.deepEqual(JSON.parse(captured.body), {
+      chat_id: 321,
+      text: "hello",
+    });
+  } finally {
+    http.request = originalRequest;
   }
 });

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -48,7 +48,6 @@ test("createTelegramClient sends JSON POST requests and returns result", async (
       chat_id: 123,
       text: "progress",
       disable_web_page_preview: true,
-      parse_mode: "MarkdownV2",
     });
   } finally {
     await new Promise((resolve, reject) => {

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import test from "node:test";
+
+import { createTelegramClient } from "../src/telegram.js";
+
+test("createTelegramClient sends JSON POST requests and returns result", async () => {
+  const requests = [];
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.setEncoding("utf8");
+    req.on("data", (chunk) => {
+      body += chunk;
+    });
+    req.on("end", () => {
+      requests.push({
+        method: req.method,
+        url: req.url,
+        headers: req.headers,
+        body: JSON.parse(body),
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, result: { delivered: true } }));
+    });
+  });
+
+  await new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  try {
+    const address = server.address();
+    const client = createTelegramClient(`http://127.0.0.1:${address.port}`);
+    const result = await client.telegram("sendMessage", {
+      chat_id: 123,
+      text: "hello",
+    });
+
+    assert.deepEqual(result, { delivered: true });
+    assert.equal(requests.length, 1);
+    assert.equal(requests[0].method, "POST");
+    assert.equal(requests[0].url, "/sendMessage");
+    assert.equal(requests[0].headers["content-type"], "application/json");
+    assert.deepEqual(requests[0].body, { chat_id: 123, text: "hello" });
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolve();
+      });
+    });
+  }
+});

--- a/test/telegram.test.js
+++ b/test/telegram.test.js
@@ -35,13 +35,21 @@ test("createTelegramClient sends JSON POST requests and returns result", async (
       chat_id: 123,
       text: "hello",
     });
+    const sent = await client.sendText(123, "progress");
 
     assert.deepEqual(result, { delivered: true });
-    assert.equal(requests.length, 1);
+    assert.deepEqual(sent, { delivered: true });
+    assert.equal(requests.length, 2);
     assert.equal(requests[0].method, "POST");
     assert.equal(requests[0].url, "/sendMessage");
     assert.equal(requests[0].headers["content-type"], "application/json");
     assert.deepEqual(requests[0].body, { chat_id: 123, text: "hello" });
+    assert.deepEqual(requests[1].body, {
+      chat_id: 123,
+      text: "progress",
+      disable_web_page_preview: true,
+      parse_mode: "MarkdownV2",
+    });
   } finally {
     await new Promise((resolve, reject) => {
       server.close((error) => {


### PR DESCRIPTION
## 무엇을 바꿨나
Codex Telegram Bot의 실행 엔진을 `codex exec --json` 직접 파싱 방식에서 `@openai/codex-sdk` 기반으로 전환했습니다. 동시에 텔레그램에서 읽기 쉬운 진행/결과/오류 포맷과 CLI 감각의 명령 alias를 정리했습니다.

## 주요 변경
- `@openai/codex-sdk` 추가 및 `src/codex-sdk.js` 래퍼 도입
- `runCodexSession()`을 SDK `runStreamed()` 기반으로 교체
- 진행 상태 메시지, 최종 결과, 오류 메시지 템플릿 정리
- 최종 결과 footer에 `thread`, `branch`, `usage` 표시 추가
- `/thread`, `/threads`, `/cwd`, `/resume` alias 추가 및 help 문구를 Codex Core / Telegram Extras로 재구성
- Markdown 적용 범위를 결과/진행/오류 템플릿으로 한정해 메뉴/목록 메시지 파싱 오류 수정

## 왜 바꿨나
기존 봇은 시작 알림 후 최종 결과만 보여주는 비중이 커서 Codex CLI와 같이 일하는 느낌이 약했습니다. 또 `exec --json` 직접 파싱과 파일 출력 의존이 있어 실행 레이어 유지보수 비용이 컸습니다.

## 영향
- 세션 상태, worktree, 최근 세션 관리 구조는 유지됩니다.
- 실행 레이어만 SDK로 바뀌어 thread 재개와 이벤트 소비를 더 안정적으로 다룰 수 있습니다.
- 텔레그램 출력은 더 읽기 쉬워지고, 최종 footer에서 현재 branch/thread/usage를 확인할 수 있습니다.

## 검증
- `npm test`
- `systemctl --user restart codex-telegram-bot`
- SDK 단독 호출로 thread 생성/응답 반환 확인
